### PR TITLE
list version numbers in uses of ffi-lib

### DIFF
--- a/wrap.rkt
+++ b/wrap.rkt
@@ -7,8 +7,8 @@
          racket/format)
 
 
-(define-ffi-definer gslcblas (ffi-lib "libgslcblas" #:global? #t))
-(define-ffi-definer gsl (ffi-lib "libgsl"  #:global? #t))
+(define-ffi-definer gslcblas (ffi-lib "libgslcblas" '("0" #f) #:global? #t))
+(define-ffi-definer gsl (ffi-lib "libgsl" '("27" #f)  #:global? #t))
 ;(define-ffi-definer gslwrap (ffi-lib "./wrap/libgslwrap" #:global? #t))
 
 


### PR DESCRIPTION
It looks like the current version of the code works only with versionless shared libraries, and won't therefore work on (e.g.) debian or ubuntu after using apt-get to install libgsl. In order to make this work, it appears necessary to specify acceptable version numbers. Based on some really cursory research, it appears to me that this code "works" (that is, loads without error) with version 27 of libgsl and version 0 of libgslcblas. This pull request specifies that these are acceptable versions, and loads them. 